### PR TITLE
Fix example code of Configure Webpack

### DIFF
--- a/docs/guide/update-webpack-config.md
+++ b/docs/guide/update-webpack-config.md
@@ -23,7 +23,7 @@ module.exports = {
 module.exports = {
   configureWebpack(config, context) {
     // Do something like adding a plugin
-    config.push.plugins(new BundleAnalyzerPlugin())
+    config.plugins.push(new BundleAnalyzerPlugin())
     // optionally return config
   }
 }


### PR DESCRIPTION
Maybe `config.push.plugins(new BundleAnalyzerPlugin())` should be `config.plugins.push(new BundleAnalyzerPlugin())`?