### PR TITLE
fixing error in options.filename.image(s) and .font(s)

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -164,7 +164,7 @@ Output filename for `.css` files.
 
 Output filename for lazy-loaded chunk files.
 
-#### font
+#### fonts
 
 - __Type__: `string`
 - __Default__: `assets/fonts/[name].[hash:8].[ext]` in `poi build`, `assets/fonts/[name].[ext]` otherwise.
@@ -172,7 +172,7 @@ Output filename for lazy-loaded chunk files.
 
 Output filename for font files.
 
-#### image
+#### images
 
 - __Type__: `string`
 - __Default__: `assets/images/[name].[hash:8].[ext]`


### PR DESCRIPTION
This two lines are using `images` instead of `image` and `fonts` instead of `font`:
https://github.com/leptosia/poi/blob/v10/packages/core/rules/image.js#L8
https://github.com/leptosia/poi/blob/v10/packages/core/rules/font.js#L8
That cost me several unforgetable debugging moments.

