### PR TITLE
Fix Two Mistakes in "Custom HTML Template" Page

### DIFF
--- a/docs/guide/custom-html-template.md
+++ b/docs/guide/custom-html-template.md
@@ -16,7 +16,7 @@ The template file uses [lodash.template](https://lodash.com/docs/4.17.11#templat
 
 ### html
 
-`html` is basically the `html` option you passed [here](../config.md#html).
+`html` is basically the `html` option you passed [here](../config.md#output-html).
 
 ### pkg
 

--- a/docs/guide/custom-html-template.md
+++ b/docs/guide/custom-html-template.md
@@ -1,6 +1,6 @@
 # Custom HTML Template
 
-When you're using JavaScript entrypoinys, `index.html` will be generated from a HTML template file, this is the [default one](https://github.com/egoist/poi/blob/master/core/poi/lib/webpack/default-template.html) we use:
+When you're using JavaScript entrypoints, `index.html` will be generated from a HTML template file, this is the [default one](https://github.com/egoist/poi/blob/master/core/poi/lib/webpack/default-template.html) we use:
 
 <<< @/data/default-template.html
 


### PR DESCRIPTION
- Spelling of `entrypoints`. Fixes #18 
- URL of `output.html` configuration
